### PR TITLE
disable geoip rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /yeager
 COPY . .
 RUN mkdir release &&\
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o release/yeager ./cmd/main.go &&\
-    wget https://github.com/v2fly/domain-list-community/raw/release/dlc.dat -O release/geosite.dat &&\
-    wget https://github.com/v2fly/geoip/raw/release/geoip.dat -O release/geoip.dat
+    wget https://github.com/v2fly/domain-list-community/raw/release/dlc.dat -O release/geosite.dat
 
 FROM alpine:latest
 WORKDIR /

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Note: yeager is my personal training project, mostly learn from v2ray-core and xray-core, and do it in my way. If you are beginner looking for proxy tool, please consider [v2ray-core](https://github.com/v2fly/v2ray-core) or [Xray-core](https://github.com/XTLS/Xray-core) firstly, they are strong enough and having better community support.
 
-yeager aims to bypass network restriction, has the basic features:
+yeager aims to bypass network restriction, supports features:
 
 - socks5, http inbound proxy
 - lightweight outbound proxy, secure transport via:
@@ -77,7 +77,6 @@ Edit config file`/usr/local/etc/yeager/config.json`
 The priority of rules is the order in config, the form could be `ruleType,value,outboundTag` and `FINAL,outboundTag`, for example:
 
 - `IP-CIDR,127.0.0.1/8,DIRECT ` matches if the traffic IP is in specified CIDR
-- `GEOIP,cn,DIRECT` matches if the traffic IP is in [geoip](https://github.com/v2fly/geoip)
 - `DOMAIN,www.apple.com,DIRECT` matches if the traffic domain is the given one
 - `DOMAIN-SUFFIX,apple.com,DIRECT` matches if the traffic domain has the suffix, AKA subdomain name
 - `DOMAIN-KEYWORD,apple,DIRECT ` matches if the traffic domain has the keyword
@@ -136,7 +135,7 @@ docker run \
 	en180706/yeager
 ```
 
-## Update
+## Upgrade
 
 Homebrew:
 

--- a/router/matcher.go
+++ b/router/matcher.go
@@ -25,8 +25,8 @@ func newRuleMatcher(ruleType string, value string) (m matcher, err error) {
 		m, err = newGeoSiteMatcher(value)
 	case ruleIPCIDR:
 		m, err = newCIDRMatcher(value)
-	case ruleGeoIP:
-		m, err = newGeoIPMatcher(value)
+	// case ruleGeoIP:
+	// 	m, err = newGeoIPMatcher(value)
 	case ruleFinal:
 		m = newFinalMatcher()
 	default:

--- a/router/route_test.go
+++ b/router/route_test.go
@@ -75,12 +75,12 @@ func TestRouter_Dispatch(t *testing.T) {
 			args:   args{addr: proxy.NewAddress("192.168.1.1", 80)},
 			want:   "faketag",
 		},
-		{
-			name:   "geoip",
-			fields: fields{rules: []string{"geoip,private,faketag"}},
-			args:   args{addr: proxy.NewAddress("192.168.1.1", 80)},
-			want:   "faketag",
-		},
+		// {
+		// 	name:   "geoip",
+		// 	fields: fields{rules: []string{"geoip,private,faketag"}},
+		// 	args:   args{addr: proxy.NewAddress("192.168.1.1", 80)},
+		// 	want:   "faketag",
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The geoip.dat was only 4MB size, but now it is 46MB. While yeager startup with it, the memory usage raise up to 300MB. Considering GEOIP rule is not the essential feature, I disable it, so that the startup memory would beneath 15MB.